### PR TITLE
use kaniko for reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,9 @@
 *.swp
 silver2.pem
 
+# don't commit kaniko-generated images
+*kaniko.tar
+
 # don't commit enclave files
 *.eif
+


### PR DESCRIPTION
- I also bumped the default elastic block store (EBS) size 8Gb -> 32 Gb.